### PR TITLE
Add some flags from regular cat; handle multiflags

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Colorize your terminal output with pride!
 
 -h,--help
 	Display the help page
+
+-n,--number
+	number all output lines
+
+-E,--show-ends
+	display $ at the end of each line
+
+-s,--squeeze-blank
+	suppress repeated empty output lines
+
+-b,--number-nonblank
+	number nonempty output lines, overrides -n
 ```
 
 ## Building

--- a/main.cpp
+++ b/main.cpp
@@ -341,6 +341,9 @@ void catFile(std::istream& fh) {
 			repeatedEmpty = true;
 			g_blankLines++;
 		}
+		else {
+			repeatedEmpty = false;
+		}
 		g_currentRow++;
 		setColor(g_colorQueue[g_currentRow % g_colorQueue.size()]);
 		if (g_numberLines) {


### PR DESCRIPTION
added some of the flags on the man page of my ubuntu version of cat

in implementing all of these flags, it was easier to use std::getline
instead of getc and putc
this required some changes around file opening and the handling of
stdin

also added the feature that single hyphen flags can be combined together
into a large group such as -ft, -Ebtfns, etc.
I thought about using getoptlong, but it seems to be more of a pain than
it's worth
one could use a vector to set up the array of struct options, but the
repetition needed to double check the args coming in is annoying.

also moved the usage print to a separate function because I wanted to
print the usage in a second spot when a bad hyphen flag is specified

feel free to comment on code style guidelines and such. I tested out
all my changes on my system, but I will gladly await others' tests.
I really only foresee like 1 or 2 people wanting the `-n` flag, but it was
kinda fun to implement the others anyway.