### PR TITLE
tiny adjustment to lesbian flag colors for 256color displays

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -107,7 +107,8 @@ std::map<std::string, flag_t const> allFlags = {
 	{ "new-lesbian", {
 		// info: https://en.wikipedia.org/wiki/LGBT_symbols#Lesbian
 		// colors: https://en.wikipedia.org/wiki/File:Lesbian_pride_flag_2018.svg
-		{ 0xD52D00, 0xEF7627, 0xFF9A56, 0xFFFFFF, 0xD162A4, 0xB55690, 0xA30262 },
+		// second-last color changed from 0xB55690 to 0xB55590 to ensure distinct colors on non-truecolor displays
+		{ 0xD52D00, 0xEF7627, 0xFF9A56, 0xFFFFFF, 0xD162A4, 0xB55590, 0xA30262 },
 		"New lesbian pride flag designed by Emily Gwen in 2018"
 	} },
 


### PR DESCRIPTION
before:
<img width="201" alt="Screenshot 2020-06-19 at 17 17 50" src="https://user-images.githubusercontent.com/2166769/85156027-684a0d00-b251-11ea-872e-fdada5773dc0.png">

after:
<img width="202" alt="Screenshot 2020-06-19 at 17 18 16" src="https://user-images.githubusercontent.com/2166769/85156031-68e2a380-b251-11ea-820b-f9f273a5bb30.png">

The issue still occurs with `--darken` enabled but I'm less worried about accurate color reproduction for the accessibility case. pictured:
<img width="487" alt="Screenshot 2020-06-19 at 17 22 42" src="https://user-images.githubusercontent.com/2166769/85156273-bfe87880-b251-11ea-9edf-e1b50121ebef.png">

I have some thoughts about improvements to the color-adjustment system that may resolve that issue regardless.